### PR TITLE
Handle zero thresholds in scheduled task script

### DIFF
--- a/setup-scheduled-task.ps1
+++ b/setup-scheduled-task.ps1
@@ -11,6 +11,8 @@
 #               [-PerformanceLog <path>] [-DiskUsageLog <path>] [-EventLog <path>] \
 #               [-NetworkLog <path>] [-CpuThreshold <percent>] [-DiskUsageThreshold <percent>]
 # ----------------------------------------------------------------------------
+# Revision : Updated parameter checks to use PSBoundParameters.ContainsKey so
+#             zero can be passed as a valid threshold value.
 [CmdletBinding()]
 param(
     [ValidateSet('Hourly','Daily')]
@@ -67,8 +69,14 @@ if ($Remove.IsPresent) {
 $trigger = New-TaskTrigger -Freq $Frequency
 
 $sysArgs = "-File `"$sysScript`" -PerformanceLog `"$PerformanceLog`" -DiskUsageLog `"$DiskUsageLog`" -EventLog `"$EventLog`""
-if ($CpuThreshold) { $sysArgs += " -CpuThreshold $CpuThreshold" }
-if ($DiskUsageThreshold) { $sysArgs += " -DiskUsageThreshold $DiskUsageThreshold" }
+# PSBoundParameters.ContainsKey allows zero to be treated as a valid value
+# rather than an indication that the parameter was omitted.
+if ($PSBoundParameters.ContainsKey('CpuThreshold')) {
+    $sysArgs += " -CpuThreshold $CpuThreshold"
+}
+if ($PSBoundParameters.ContainsKey('DiskUsageThreshold')) {
+    $sysArgs += " -DiskUsageThreshold $DiskUsageThreshold"
+}
 $netArgs = "-File `"$netScript`" -NetworkLog `"$NetworkLog`""
 
 # Each action starts PowerShell with the script path and log file arguments.

--- a/tests/maintenance.Tests.ps1
+++ b/tests/maintenance.Tests.ps1
@@ -53,6 +53,16 @@ Describe 'setup-scheduled-task.ps1' {
         $script:argsCaptured | Should -Match '-DiskUsageThreshold 80'
     }
 
+    It 'forwards zero values for thresholds' {
+        Mock Register-ScheduledTask {
+            param($TaskName, $TaskPath, $Action, $Trigger, $Force, $Description)
+            $script:zeroArgs = $Action.Argument
+        }
+        & "$PSScriptRoot/../setup-scheduled-task.ps1" -CpuThreshold 0 -DiskUsageThreshold 0
+        $script:zeroArgs | Should -Match '-CpuThreshold 0'
+        $script:zeroArgs | Should -Match '-DiskUsageThreshold 0'
+    }
+
     It 'throws when threshold values are out of range' {
         { & "$PSScriptRoot/../setup-scheduled-task.ps1" -CpuThreshold 200 } | Should -Throw
         { & "$PSScriptRoot/../setup-scheduled-task.ps1" -DiskUsageThreshold -5 } | Should -Throw


### PR DESCRIPTION
## Summary
- allow zero threshold values in setup-scheduled-task.ps1
- verify zero values are forwarded in the maintenance tests

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests -Output Detailed"` *(fails: Invoke-Pester not found)*