### PR TITLE
Improve error handling for module imports

### DIFF
--- a/network_traffic.ps1
+++ b/network_traffic.ps1
@@ -7,6 +7,8 @@
 #             the sleep interval is always a positive integer.
 # Usage:      .\network_traffic.ps1 [-NetworkLog <path>] [-SleepInterval <seconds>] [-Iterations <count>]
 # ----------------------------------------------------------------------------
+# Revision:   Added module import validation to surface clear errors when
+#             dependencies cannot be loaded.
 
 [CmdletBinding()]
 param(
@@ -19,7 +21,14 @@ param(
     [int]$Iterations = [int]::MaxValue
 )
 
-Import-Module "$PSScriptRoot/MonitoringTools.psd1"
+try {
+    # Load the MonitoringTools module from this repository. Using -ErrorAction
+    # Stop causes a terminating error if the module cannot be found, which we
+    # trap to provide a user friendly message.
+    Import-Module "$PSScriptRoot/MonitoringTools.psd1" -ErrorAction Stop
+} catch {
+    throw "Failed to import MonitoringTools module: $_"
+}
 
 # Iterate up to the requested number of times. With the default value this
 # behaves like the prior infinite while loop used for continuous logging.

--- a/setup-scheduled-task.ps1
+++ b/setup-scheduled-task.ps1
@@ -13,6 +13,8 @@
 # ----------------------------------------------------------------------------
 # Revision : Updated parameter checks to use PSBoundParameters.ContainsKey so
 #             zero can be passed as a valid threshold value.
+#             Added module import verification for clearer failures when the
+#             MonitoringTools module is missing.
 [CmdletBinding()]
 param(
     [ValidateSet('Hourly','Daily')]
@@ -32,6 +34,14 @@ param(
 # Windows, so bail out early if it cannot be found.
 if (-not (Get-Command Register-ScheduledTask -ErrorAction SilentlyContinue)) {
     throw 'Scheduled tasks are only supported on Windows platforms.'
+}
+
+try {
+    # Load the module so task arguments can be validated before scheduling. A
+    # missing module would otherwise cause runtime failures when the tasks run.
+    Import-Module "$PSScriptRoot/MonitoringTools.psd1" -ErrorAction Stop
+} catch {
+    throw "Failed to import MonitoringTools module: $_"
 }
 
 $taskPath = '\MonitoringTools'       # Folder in Task Scheduler for grouping tasks

--- a/system_monitoring.ps1
+++ b/system_monitoring.ps1
@@ -18,6 +18,8 @@
 #             Suitable for use with
 #             scheduled tasks or manual execution.
 # ----------------------------------------------------------------------------
+# Revision:   Added explicit error handling for loading the MonitoringTools
+#             module to provide clear feedback when dependencies are missing.
 
 [CmdletBinding()]
 param(
@@ -36,7 +38,14 @@ param(
     [int]$Iterations = [int]::MaxValue
 )
 
-Import-Module "$PSScriptRoot/MonitoringTools.psd1"
+try {
+    # Import the monitoring module from the repository path. -ErrorAction Stop
+    # ensures an exception is thrown when the module cannot be loaded so the
+    # catch block can present a clear failure reason.
+    Import-Module "$PSScriptRoot/MonitoringTools.psd1" -ErrorAction Stop
+} catch {
+    throw "Failed to import MonitoringTools module: $_"
+}
 
 # Repeat the monitoring cycle the requested number of times. Leaving
 # -Iterations at the default effectively continues indefinitely.

--- a/tests/maintenance.Tests.ps1
+++ b/tests/maintenance.Tests.ps1
@@ -67,6 +67,12 @@ Describe 'setup-scheduled-task.ps1' {
         { & "$PSScriptRoot/../setup-scheduled-task.ps1" -CpuThreshold 200 } | Should -Throw
         { & "$PSScriptRoot/../setup-scheduled-task.ps1" -DiskUsageThreshold -5 } | Should -Throw
     }
+
+    It 'throws when module import fails' {
+        Mock Import-Module { throw 'missing' }
+        { & "$PSScriptRoot/../setup-scheduled-task.ps1" } | Should -Throw -ErrorMessage 'Failed to import MonitoringTools module:'
+        Remove-Mock Import-Module
+    }
 }
 
 Describe 'system_monitoring.ps1 parameter validation' {

--- a/tests/system_monitoring.Tests.ps1
+++ b/tests/system_monitoring.Tests.ps1
@@ -272,3 +272,16 @@ Describe 'Script iteration limits' {
         Remove-Mock Start-Sleep
     }
 }
+
+Describe 'Module loading errors' {
+    It 'system script throws when module import fails' {
+        Mock Import-Module { throw 'missing' }
+        { & "$PSScriptRoot/../system_monitoring.ps1" -Iterations 1 -ErrorAction Stop } | Should -Throw -ErrorMessage 'Failed to import MonitoringTools module:'
+        Remove-Mock Import-Module
+    }
+    It 'network script throws when module import fails' {
+        Mock Import-Module { throw 'missing' }
+        { & "$PSScriptRoot/../network_traffic.ps1" -Iterations 1 -ErrorAction Stop } | Should -Throw -ErrorMessage 'Failed to import MonitoringTools module:'
+        Remove-Mock Import-Module
+    }
+}


### PR DESCRIPTION
## Summary
- ensure MonitoringTools module import errors stop execution
- add module import checks to network_traffic and setup-scheduled-task scripts
- test that scripts throw when module imports fail

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests"` *(fails: command not found)*