### PR TITLE
Validate InterfaceName parameter

### DIFF
--- a/network_traffic.ps1
+++ b/network_traffic.ps1
@@ -15,6 +15,8 @@
 #             loaded.
 #             Removed sleep after the final iteration so the script exits
 #             immediately when iteration limits are reached.
+#             Validates that -InterfaceName values are not empty strings so
+#             accidental blank arguments are caught early.
 
 [CmdletBinding()]
 param(
@@ -27,7 +29,10 @@ param(
     [int]$Iterations = [int]::MaxValue,
     # Optional list of adapter names or indexes to monitor. When omitted all
     # active adapters are logged. Names and indexes are compared as strings so
-    # either `Ethernet` or `1` work interchangeably.
+    # either `Ethernet` or `1` work interchangeably. ValidateNotNullOrEmpty
+    # rejects empty strings, preventing useless iterations when a blank value is
+    # supplied.
+    [ValidateNotNullOrEmpty()]
     [string[]]$InterfaceName
 )
 

--- a/tests/system_monitoring.Tests.ps1
+++ b/tests/system_monitoring.Tests.ps1
@@ -410,4 +410,9 @@ Describe 'Loop parameter validation' {
         { & "$PSScriptRoot/../network_traffic.ps1" -Iterations 0 } | Should -Throw
         { & "$PSScriptRoot/../network_traffic.ps1" -Iterations -1 } | Should -Throw
     }
+    # Validate that interface names cannot be empty strings so parameter
+    # validation prevents useless iterations when the argument is blank.
+    It 'network script rejects empty interface name' {
+        { & "$PSScriptRoot/../network_traffic.ps1" -InterfaceName '' } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- prevent blank interface names in `network_traffic.ps1`
- check that empty interface values throw in tests

## Testing
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester tests -Output Detailed` *(fails: Invoke-Pester not found)*